### PR TITLE
tetsi-2770 (bug) [SonarQube] Remove the declaration of the unused 'result' variable.

### DIFF
--- a/nodejs/config.js
+++ b/nodejs/config.js
@@ -1,5 +1,5 @@
 function unusedLogic() {
-    let result;
+    // let result; // Remove the declaration of the unused 'result' variable
 }
 
 function calculateDiscount(price, discount) {


### PR DESCRIPTION
tetsi-2770 (bug) [SonarQube] Remove the declaration of the unused 'result' variable.