### PR TITLE
sonar-6 (bug) [SonarQube] Remove the declaration of the unused 'url2' variable.

### DIFF
--- a/node.js
+++ b/node.js
@@ -29,7 +29,7 @@ app.get('/greet', (req, res) => {
 });
 
 app.get('/redirect', (req, res) => {
-    const { url ,url2 } = req.query;
+    const { url } = req.query;
     res.redirect(url);
 });
 


### PR DESCRIPTION
sonar-6 (bug) [SonarQube] Remove the declaration of the unused 'url2' variable.